### PR TITLE
Update configuration-as-code to 1.35, cleanup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,8 +44,10 @@ jenkins_casc_script_timeout: 60
 # Plugins needed for configuration-as-code
 jenkins_casc_plugins_present:
   - name: configuration-as-code
-    version: "1.34"
-  - name: configuration-as-code-support
-    version: "1.18"
+    version: "1.35"
   - name: configuration-as-code-groovy
     version: "1.1"
+
+# Plugins no longer needed for configuration-as-code
+jenkins_casc_plugins_absent:
+  - name: configuration-as-code-support


### PR DESCRIPTION
configuration-as-code-support is not required anymore, so removing it.